### PR TITLE
Test if directory exists using `dir.exists`

### DIFF
--- a/R/checkX13.R
+++ b/R/checkX13.R
@@ -45,7 +45,7 @@ checkX13 <- function(fail = FALSE, fullcheck = TRUE, htmlcheck = TRUE){
   }
   
   ### check validity of path
-  if (!file.exists(env.path)){
+  if (!dir.exists(env.path)){
     invalid.path.message <- paste0("Path '", env.path, "' specified but does not exists.")
     if (fail){
       message(invalid.path.message)


### PR DESCRIPTION
Do this because `file.exists` returns `TRUE` for both a file and a directory, but will fail to successfully identify a directory with a trailing backslash or slash on Windows. `dir.exists` will not return `TRUE` for files and will identify directories with and without trailing slashes.

I ran into this issue when I had manually set my `X13_PATH` to `...\\x13asall_V1.1_B26\\x13as\\` and kept receiving this error message:
```
Path '...\x13asall_V1.1_B26\x13as\' specified but does not exists.
```


Note: This has **not** been tested in a linux/unix environment.