### PR TITLE
[wip] M1 escape

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: seasonal
 Type: Package
 Title: R Interface to X-13-ARIMA-SEATS
-Version: 1.8.2
-Date: 2021-03-23
+Version: 1.8.3
+Date: 2021-04-10
 Authors@R: c(
     person("Christoph", "Sax", email = "christoph.sax@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-7192-7044")),
     person("Dirk", "Eddelbuettel", role = c("ctb"), comment = c(ORCID = "0000-0001-6419-907X"))

--- a/R/startup.R
+++ b/R/startup.R
@@ -1,4 +1,10 @@
 .onLoad <- function(...){
+
+  # works fine on Mac M1 - no on load testing to avoid detritus NOTE
+  if (R.version$arch == "aarch64"){
+    return(invisible(NULL))
+  }
+
   if (Sys.getenv("X13_PATH") != ""){
     if (x13binary::supportedPlatform()){
       # skip this message if X13_PATH is set to x13binary.path

--- a/tests/testthat/test-cran.R
+++ b/tests/testthat/test-cran.R
@@ -1,5 +1,11 @@
 # --- Startup tests ------------------------------------------------------------
 
+# works fine on Mac M1 - no on load testing to avoid detritus NOTE
+testthat::skip_if(
+  R.version$arch == "aarch64",
+  "skip on CRAN mac M1"
+)
+
 x13binary::checkX13binary()
 
 


### PR DESCRIPTION
Let's see what happens on the x13binary front. But once it is up, escaping M1 on CRAN tests may solve the NOTE issue, if they *still* appear on x13binary.

For testing purposes, on M1, I added a `stop()` to `seas()` to make sure `R CMD check --as-cran` never touches it (with `_R_CHECK_DONTTEST_EXAMPLES_=false`).
