### PR TITLE
Avoid setting X13_PATH environment variable

### DIFF
--- a/R/checkX13.R
+++ b/R/checkX13.R
@@ -25,14 +25,14 @@
 checkX13 <- function(fail = FALSE, fullcheck = TRUE, htmlcheck = TRUE){
 
   if (fullcheck){
-    if (identical(Sys.getenv("X13_PATH"), (x13binary::x13path()))){
+    if (identical(get_x13_path(), (x13binary::x13path()))){
       message("seasonal is using the X-13 binaries provided by x13binary")
     }
   }
 
   ### check path
   no.path.message <- "No path to the binary executable of X-13 specified.\n\nYou can set 'X13_PATH' manually if you intend to use your own\nbinaries. See ?seasonal for details.\n"
-  env.path <- Sys.getenv("X13_PATH")
+  env.path <- get_x13_path()
 
   if (env.path == ""){
     if (fail){
@@ -148,7 +148,7 @@ checkX13 <- function(fail = FALSE, fullcheck = TRUE, htmlcheck = TRUE){
 
     if (has.failed){
       message("\nError details:")
-      message("  - X13_PATH:         ", Sys.getenv("X13_PATH"))
+      message("  - X13_PATH:         ", get_x13_path())
       message("  - Full binary path: ", x13.bin)
       message("  - Platform:         ", R.version$platform)
       message("  - R-Version:        ", R.version$version.string)
@@ -179,3 +179,10 @@ checkX13 <- function(fail = FALSE, fullcheck = TRUE, htmlcheck = TRUE){
 
 }
 
+get_x13_path <- function() {
+  env_path <- Sys.getenv("X13_PATH")
+  if (env_path != "") {
+    return(env_path)
+  }
+  x13binary::x13path()
+}

--- a/R/checkX13.R
+++ b/R/checkX13.R
@@ -32,9 +32,9 @@ checkX13 <- function(fail = FALSE, fullcheck = TRUE, htmlcheck = TRUE){
 
   ### check path
   no.path.message <- "No path to the binary executable of X-13 specified.\n\nYou can set 'X13_PATH' manually if you intend to use your own\nbinaries. See ?seasonal for details.\n"
-  env.path <- get_x13_path()
+  x13_path <- get_x13_path()
 
-  if (env.path == ""){
+  if (x13_path == ""){
     if (fail){
       message(no.path.message)
       stop("Process terminated")
@@ -45,8 +45,8 @@ checkX13 <- function(fail = FALSE, fullcheck = TRUE, htmlcheck = TRUE){
   }
 
   ### check validity of path
-  if (!file.exists(env.path)){
-    invalid.path.message <- paste0("Path '", env.path, "' specified but does not exists.")
+  if (!file.exists(x13_path)){
+    invalid.path.message <- paste0("Path '", x13_path, "' specified but does not exists.")
     if (fail){
       message(invalid.path.message)
       stop("Process terminated")
@@ -59,17 +59,17 @@ checkX13 <- function(fail = FALSE, fullcheck = TRUE, htmlcheck = TRUE){
   ### check existence of binaries
   # platform dependent binaries
   if (.Platform$OS.type == "windows"){
-    x13.bin <- file.path(env.path, "x13as.exe")
-    x13.bin.html <- file.path(env.path, "x13ashtml.exe")
+    x13.bin <- file.path(x13_path, "x13as.exe")
+    x13.bin.html <- file.path(x13_path, "x13ashtml.exe")
   } else {
-    x13.bin <- file.path(env.path, "x13as")
+    x13.bin <- file.path(x13_path, "x13as")
     # ignore case on unix to avoid problems with different binary names
-    fl <- list.files(env.path)
+    fl <- list.files(x13_path)
     fn <- fl[grepl("^x13ashtml$", fl, ignore.case = TRUE)]
     if (length(fn) > 0){
-      x13.bin.html <- file.path(env.path, fn)
+      x13.bin.html <- file.path(x13_path, fn)
     } else {
-      x13.bin.html <- file.path(env.path, "x13ashtml")
+      x13.bin.html <- file.path(x13_path, "x13ashtml")
     }
   }
   no.file.message <- paste("Binary executable file", x13.bin, "or", x13.bin.html, "not found.\nSee ?seasonal for details.\n")
@@ -100,17 +100,17 @@ checkX13 <- function(fail = FALSE, fullcheck = TRUE, htmlcheck = TRUE){
 
     if (.Platform$OS.type == "windows"){
       if (getOption("htmlmode") == 1){
-        x13.bin <- paste0("\"", file.path(env.path, "x13ashtml.exe"), "\"")
+        x13.bin <- paste0("\"", file.path(x13_path, "x13ashtml.exe"), "\"")
       } else {
-        x13.bin <- paste0("\"", file.path(env.path, "x13as.exe"), "\"")
+        x13.bin <- paste0("\"", file.path(x13_path, "x13as.exe"), "\"")
       }
     } else {
       if (getOption("htmlmode") == 1){
         # ignore case on unix to avoid problems with different binary names
-        fl <- list.files(env.path)
-        x13.bin <- file.path(env.path, fl[grepl("^x13ashtml$", fl, ignore.case = TRUE)])
+        fl <- list.files(x13_path)
+        x13.bin <- file.path(x13_path, fl[grepl("^x13ashtml$", fl, ignore.case = TRUE)])
       } else {
-        x13.bin <- file.path(env.path, "x13as")
+        x13.bin <- file.path(x13_path, "x13as")
       }
     }
 
@@ -165,10 +165,10 @@ checkX13 <- function(fail = FALSE, fullcheck = TRUE, htmlcheck = TRUE){
         packageStartupMessage("\nseasonal now supports the HTML version of X13, which offers a more\naccessible output via the out() function. For best user experience, \ndownload the HTML version from:",
                               "\n\n  https://www.census.gov/data/software/x13as.X-13ARIMA-SEATS.html\n\n",
                               "and copy x13ashtml.exe to:\n\n",
-                              "  ", env.path)
+                              "  ", x13_path)
       } else {
         packageStartupMessage("\nseasonal now supports the HTML version of X13, which offers a more \naccessible output via the out() function. For best user experience, \ncopy the binary executables of x13ashtml to:\n\n",
-                              "  ", env.path)
+                              "  ", x13_path)
       }
     }
   }

--- a/R/startup.R
+++ b/R/startup.R
@@ -40,7 +40,6 @@
         "\nbinaries. See ?seasonal for details.\n"
       ))
     }
-    Sys.setenv(X13_PATH = x13binary::x13path())
   }
   checkX13(fullcheck = FALSE, htmlcheck = TRUE)
 

--- a/R/x13_run.R
+++ b/R/x13_run.R
@@ -7,7 +7,7 @@ x13_run <- function(file, out, meta = FALSE){
   #
   # required by seas
 
-  env.path <- get_x13_path()
+  x13_path <- get_x13_path()
 
   # -n output suppression (no out file)
   # -s store additional output (.udg file)
@@ -16,9 +16,9 @@ x13_run <- function(file, out, meta = FALSE){
   m_flag <- if (meta) "-m" else ""
   if (.Platform$OS.type == "windows"){
     if (getOption("htmlmode") == 1){
-      x13.bin <- paste0("\"", normalizePath(file.path(env.path, "x13ashtml.exe")), "\"")
+      x13.bin <- paste0("\"", normalizePath(file.path(x13_path, "x13ashtml.exe")), "\"")
     } else {
-      x13.bin <- paste0("\"", normalizePath(file.path(env.path, "x13as.exe")), "\"")
+      x13.bin <- paste0("\"", normalizePath(file.path(x13_path, "x13as.exe")), "\"")
     }
     # change wd on win as X-13 writes `fort.6` to it
     owd <- getwd()
@@ -29,10 +29,10 @@ x13_run <- function(file, out, meta = FALSE){
   } else {
     if (getOption("htmlmode") == 1){
       # ignore case on unix to avoid problems with different binary names
-      fl <- list.files(env.path)
-      x13.bin <- file.path(env.path, fl[grepl("^x13ashtml$", fl, ignore.case = TRUE)])
+      fl <- list.files(x13_path)
+      x13.bin <- file.path(x13_path, fl[grepl("^x13ashtml$", fl, ignore.case = TRUE)])
     } else {
-      x13.bin <- file.path(env.path, "x13as")
+      x13.bin <- file.path(x13_path, "x13as")
     }
     # change wd in meta mode, as it wirtes `fort.14` to it
     if (meta) {

--- a/R/x13_run.R
+++ b/R/x13_run.R
@@ -7,7 +7,8 @@ x13_run <- function(file, out, meta = FALSE){
   #
   # required by seas
 
-  env.path <- Sys.getenv("X13_PATH")
+  env.path <- get_x13_path()
+
   # -n output suppression (no out file)
   # -s store additional output (.udg file)
   # -m use metafile


### PR DESCRIPTION
Closes https://github.com/christophsax/seasonal/issues/267.

Setting environment variables is a global side effect, `.onLoad()` should be free of global side effects.

Most of the noise in this PR comes from the second commit which only renames a local variable.

I see in the tests:

```
Error (test-all.R:23:3): extensive non CRAN tests succeed
Error: failing cases: 90, 95, 96, 97, 98, 99, 100
```

Will investigate.