### PR TITLE
fix message_rerun_hint with existing arguments

### DIFF
--- a/R/series.R
+++ b/R/series.R
@@ -371,7 +371,12 @@ series <- function(x, series, reeval = TRUE, verbose = TRUE){
 }
 
 message_rerun_hint <- function(call, dots) {
-  new_args <- lapply(split(dots, names(dots)), \(x) unlist(unname(x)))
+  new_args <- lapply(split(dots, names(dots)), \(x) {
+    c(
+      unlist(unname(x)), # new args
+      call[[names(x)[1]]] # if call already has this parameter filled, add it to the new ones
+    )
+  })
   call[names(new_args)] <- new_args
 
   # using a single message call because expect_message

--- a/R/series.R
+++ b/R/series.R
@@ -372,9 +372,11 @@ series <- function(x, series, reeval = TRUE, verbose = TRUE){
 
 message_rerun_hint <- function(call, dots) {
   new_args <- lapply(split(dots, names(dots)), \(x) {
-    c(
-      unlist(unname(x)), # new args
-      call[[names(x)[1]]] # if call already has this parameter filled, add it to the new ones
+    unique(
+      c(
+        unlist(unname(x)), # new args
+        call[[names(x)[1]]] # if call already has this parameter filled, add it to the new ones
+      )
     )
   })
   call[names(new_args)] <- new_args

--- a/tests/testthat/test-message_rerun_hint.R
+++ b/tests/testthat/test-message_rerun_hint.R
@@ -39,3 +39,15 @@ test_that("message_rerun_hint preserves existing args", {
     "seas\\(x, foo = c\\(\"no\", \"yes\"\\)\\)"
   )
 })
+
+test_that("message_rerun_hint does not introduce duplicates", {
+  call <- quote(seas(x, foo = "yes"))
+
+  expect_message(
+    message_rerun_hint(
+      call,
+      list(foo = "yes")
+    ),
+    "seas\\(x, foo = \"yes\"\\)"
+  )
+})

--- a/tests/testthat/test-message_rerun_hint.R
+++ b/tests/testthat/test-message_rerun_hint.R
@@ -7,6 +7,15 @@ test_that("message_rerun_hint works", {
   )
 })
 
+test_that("message_rerun_hint with multiple dots", {
+  call <- quote(seas(x))
+
+  expect_message(
+    message_rerun_hint(call, list(foo = "bar", baz = 3)),
+    "seas\\(x, baz = 3, foo = \"bar\"\\)"
+  )
+})
+
 test_that("message_rerun_hint consolidates dots with same name", {
   call <- quote(seas(x))
 
@@ -16,5 +25,17 @@ test_that("message_rerun_hint consolidates dots with same name", {
       list(foo = "bar", foo = "baz")
     ),
     "seas\\(x, foo = c\\(\"bar\", \"baz\"\\)\\)"
+  )
+})
+
+test_that("message_rerun_hint preserves existing args", {
+  call <- quote(seas(x, foo = "yes"))
+
+  expect_message(
+    message_rerun_hint(
+      call,
+      list(foo = "no")
+    ),
+    "seas\\(x, foo = c\\(\"no\", \"yes\"\\)\\)"
   )
 })


### PR DESCRIPTION
The previous version would have overwritten any arguments that were in both call and reeval.dots.
Now it consolidates them into a vector argument.

Since there are no scalar arguments in the current usage space for this helper this seems sufficient.