### PR TITLE
Do not warn by default if EOL is missing in spc file

### DIFF
--- a/R/import.spc.R
+++ b/R/import.spc.R
@@ -8,6 +8,7 @@
 #'
 #' @param file   character, path to the X-13 `.spc` file
 #' @param text   character, alternatively, the content of a `.spc` file as a character string.
+#' @param warn   a logical passed to [readLines()] if `file` is provided. `FALSE` by default.
 #' @return returns an object of class `import.spc`, which is a list with the following (optional) objects of class `call`:
 #'   \item{x}{the call to retrieve the data for the input series}
 #'   \item{xtrans}{the call to retrieve the data for the `xtrans` series (if required by the call)}

--- a/R/import.spc.R
+++ b/R/import.spc.R
@@ -98,7 +98,7 @@ import.spc <- function(file, text = NULL){
 
   if (is.null(text)){
     stopifnot(file.exists(file))
-    text <- readLines(file)
+    text <- readLines(file, warn = FALSE)
   } else {
     stopifnot(inherits(text, "character"))
     text <- paste(text, collapse = "\n")

--- a/R/import.spc.R
+++ b/R/import.spc.R
@@ -92,13 +92,13 @@
 #' ee <- lapply(ll, eval, envir = globalenv())
 #' ee$seas  # the 'seas' object, produced by the final call to seas()
 #' }
-import.spc <- function(file, text = NULL){
+import.spc <- function(file, text = NULL, warn = ifelse(!is.null(text), NULL, FALSE)){
 
   z <- list()
 
   if (is.null(text)){
     stopifnot(file.exists(file))
-    text <- readLines(file, warn = FALSE)
+    text <- readLines(file, warn = warn)
   } else {
     stopifnot(inherits(text, "character"))
     text <- paste(text, collapse = "\n")

--- a/man/import.spc.Rd
+++ b/man/import.spc.Rd
@@ -5,7 +5,7 @@
 \alias{print.import.spc}
 \title{Import X-13 \code{.spc} Files}
 \usage{
-import.spc(file, text = NULL)
+import.spc(file, text = NULL, warn = ifelse(!is.null(text), NULL, FALSE))
 
 \method{print}{import.spc}(x, ...)
 }
@@ -13,6 +13,8 @@ import.spc(file, text = NULL)
 \item{file}{character, path to the X-13 \code{.spc} file}
 
 \item{text}{character, alternatively, the content of a \code{.spc} file as a character string.}
+
+\item{warn}{a logical passed to \code{\link[=readLines]{readLines()}} if \code{file} is provided. \code{FALSE} by default.}
 
 \item{x}{object of class \code{import.spc}}
 


### PR DESCRIPTION
If a spc file without EOL is given, we get a warning. 

``` r
pkgload::load_all()
#> ℹ Loading seasonal

import.spc("inst/tests/trial.spc") # trial.spc has no EOL
#> Warning in readLines(file): incomplete final line found on
#> 'inst/tests/trial.spc'
#> ## import input series
#> x <- ts(c(112, 118, 132, 129, 121, 135, 148, 148, 136, 119, 104, 
#>     118, 115, 126, 141, 135, 125, 149, 170, 170, 158, 133, 114, 
#>     140, 145, 150, 178, 163, 172, 178, 199, 199, 184, 162, 146, 
#>     166), start = c(1949, 1), frequency = 12)
#> 
#> ## main call to 'seas'
#> seas(x = x, series.print = "brief", automdl = NULL, outlier = NULL, 
#>     regression.aictest = NULL)
```

<sup>Created on 2024-06-10 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

With this PR, we give the choice to user whether to silence it or not. By default, we make it silent.

``` r
pkgload::load_all()
#> ℹ Loading seasonal

import.spc("inst/tests/trial.spc") # trial.spc has no EOL
#> ## import input series
#> x <- ts(c(112, 118, 132, 129, 121, 135, 148, 148, 136, 119, 104, 
#>     118, 115, 126, 141, 135, 125, 149, 170, 170, 158, 133, 114, 
#>     140, 145, 150, 178, 163, 172, 178, 199, 199, 184, 162, 146, 
#>     166), start = c(1949, 1), frequency = 12)
#> 
#> ## main call to 'seas'
#> seas(x = x, series.print = "brief", automdl = NULL, outlier = NULL, 
#>     regression.aictest = NULL)
```

<sup>Created on 2024-06-10 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>