### PR TITLE
Switch http:// to https:// in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ R interface to X-13ARIMA-SEATS
 ------------------------------
 
 <!-- badges: start -->
-[![Downloads](http://cranlogs.r-pkg.org/badges/seasonal)](https://cran.r-project.org/package=seasonal)
+[![Downloads](https://cranlogs.r-pkg.org/badges/seasonal)](https://cran.r-project.org/package=seasonal)
 [![R-CMD-check](https://github.com/christophsax/seasonal/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/christophsax/seasonal/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 


### PR DESCRIPTION
Minor maintenance commit here -- I noticed that in (some, old) README.md of mine old badges still using http:// were not rendering, and that was also the case in the seasonal checkout I had for the 'cranlogs' badge. As it seemed to be the same problem 'upstream' here I made a quick PR.
